### PR TITLE
Fix LinkComponent

### DIFF
--- a/components/Link/link.component.js
+++ b/components/Link/link.component.js
@@ -33,9 +33,8 @@ export const LinkComponent = ({
     );
   }
   return (
-    <Link href="/">
+    <Link href={href}>
       <a
-        href={href}
         target={target}
         rel={rel}
         className={`


### PR DESCRIPTION
## Why

The link in https://wasmer.io/community was broken. All were links to `/`.

<img width="889" alt="スクリーンショット 2021-04-24 22 22 05" src="https://user-images.githubusercontent.com/23740172/115960324-b273dd00-a54b-11eb-9f22-fc8ae95f7f0e.png">

`<Link href="/">`
The cause was the following code. I fixed this and made the link proper.
What I found was the `community` part, but everything using LinkComponent would be broken. Some links will be fixed by this PR
Thanks.
