### PR TITLE
fix(homepage)  Update embeddings URL

### DIFF
--- a/components/Languages/languages-hero.constants.js
+++ b/components/Languages/languages-hero.constants.js
@@ -10,7 +10,7 @@ export default [
     },
   },
   {
-    url: 'https://github.com/wasmerio/wasmer-rust-example',
+    url: 'https://github.com/wasmerio/wasmer/blob/master/examples/README.md',
     name: 'Rust',
     icon: {
       image:
@@ -60,7 +60,7 @@ export default [
     },
   },
   {
-    url: 'https://github.com/wasmerio/wasmer-c-api',
+    url: 'https://github.com/wasmerio/wasmer/tree/master/lib/c-api',
     name: 'C',
     icon: {
       image:


### PR DESCRIPTION
~The list of the embeddings in the hero componnet was outdated:
Embeddings are missing and some links are incorrect. Also, icons were
defined as inline SVG while we have proper SVG files. It's code
duplication.~

~This patch proposes to change the list by a link, that points to the
full list of embeddings.~

This patch now updates just the links to the embedding for the “hero languages” component.