### PR TITLE
Add Github pages deployment workflow

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -1,0 +1,22 @@
+on: [push]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Deploy to Cloudflare Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Run your project's build step
+      # - name: Build
+      #   run: npm install && npm run build
+      - name: Publish
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: wasmer-io
+          directory: out # e.g. 'dist'
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -5,13 +5,13 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    name: Deploy to Cloudflare Pages
+    name: Direct Upload to Cloudflare Pages
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       # Run your project's build step
-      # - name: Build
-      #   run: npm install && npm run build
+      - name: Build
+        run: npm install && npm run build
       - name: Publish
         uses: cloudflare/pages-action@1
         with:


### PR DESCRIPTION
This commit adds a new workflow file pages-deployment.yaml for deploying the website to Cloudflare Pages on Github pages. The workflow is triggered on a push event and runs on the ubuntu-latest platform. The workflow defines a single job called deploy with steps to checkout the code, publish the website to Cloudflare Pages using the cloudflare/pages-action@1 action, and specify the directory for deployment. The necessary permissions for read and write access are also included.