### PR TITLE
Added fix for shell blocks in blogs

### DIFF
--- a/_posts/WAI-is-the-answer.md
+++ b/_posts/WAI-is-the-answer.md
@@ -65,25 +65,25 @@ You will need to install several CLI tools.
 
 - [The Rust toolchain](https://rustup.rs/) so we can compile Rust code
 
-```console
+```shell-session
   $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 - the `wasm32-unknown-unknown` target so Rust knows how to compile to WebAssembly
 
-```console
+```shell-session
   $ rustup target add wasm32-unknown-unknown
 ```
 
 - [The Wasmer runtime](https://docs.wasmer.io/ecosystem/wasmer/getting-started) so we can interact with WAPM
 
-```console
+```shell-session
   $ curl https://get.wasmer.io -sSfL | sh
 ```
 
 - [The `cargo wapm` sub-command](https://lib.rs/cargo-wapm) for publishing to WAPM
 
-```console
+```shell-session
   $ cargo install cargo-wapm
 ```
 
@@ -227,7 +227,7 @@ wai_bindgen_rust::export!("sgp4.wai");
 
 Now, As we included this `sgp4.wai` in our `lib.rs`. We can do a `cargo expand` as a smoke test to see if the glue code gets generated.
 
-```console
+```shell-session
 $  cargo expand
 ```
 
@@ -244,7 +244,7 @@ unsafe extern "C" fn __wai_bindgen_sgp4_constants_initial_state(arg0: i32) -> i3
 
 Let’s run `cargo check` and use the error messages to see what we need to do next.
 
-```console
+```shell-session
 $ cargo check
 
 error[E0412]: cannot find type `ResonanceState` in module `super`

--- a/_posts/wasmer-2.1.md
+++ b/_posts/wasmer-2.1.md
@@ -1,7 +1,7 @@
 ---
-title: "Wasmer 2.1"
-excerpt: "Wasmer 2.1 supporting JS, Singlepass in Windows, iOS, LLVM 13, reproducible builds and many more features"
-date: "2021-12-01T00:00:00.000Z"
+title: 'Wasmer 2.1'
+excerpt: 'Wasmer 2.1 supporting JS, Singlepass in Windows, iOS, LLVM 13, reproducible builds and many more features'
+date: '2021-12-01T00:00:00.000Z'
 author: Syrus Akbary
 published: true
 ---
@@ -19,7 +19,7 @@ After a few months of work, we are super happy to announce the general availabil
 
 Wasmer 2.1 also kicks off the company's transition to a milestone-driven public roadmap and delivery process
 
-*[Click here](https://github.com/wasmerio/wasmer/milestones) for more information on current and future milestones.*
+_[Click here](https://github.com/wasmerio/wasmer/milestones) for more information on current and future milestones._
 
 Below is a summary of some new features and highlights.
 
@@ -33,6 +33,7 @@ You can now run in the browser your Rust projects using Wasmer just by doing:
 [dependencies]
 wasmer = { version = "2.1.0", default-features=false, features=["js-default"]}
 ```
+
 **Stay tuned for a detailed blog post on how to use it!**
 
 ## Virtual Filesystem
@@ -77,20 +78,20 @@ Deterministic builds are a critical feature for many of our customers in the Web
 We couldn't be happier about the new language integrations of Wasmer created by our awesome community.
 The integrations allow developers to WebAssembly in even more languages:
 
-* [Wasmer Lisp](https://github.com/helmutkian/cl-wasm-runtime): Were you interested in using WebAssembly from a functional language? This is for you!
-* [Wasmer Crystal](https://github.com/naqvis/wasmer-crystal): [Crystal](https://crystal-lang.org/) is a Ruby-like language with C-like performance
+- [Wasmer Lisp](https://github.com/helmutkian/cl-wasm-runtime): Were you interested in using WebAssembly from a functional language? This is for you!
+- [Wasmer Crystal](https://github.com/naqvis/wasmer-crystal): [Crystal](https://crystal-lang.org/) is a Ruby-like language with C-like performance
 
 # Install Wasmer now
 
 If you already have Wasmer installed, you can upgrade to 2.1 by running
 
-```shell
+```shell-session
 wasmer self-update
 ```
 
 If you are installing Wasmer for the first time, you can use one of the methods listed below:
 
-```shell
+```shell-session
 # Using Shell (macOS and Linux):
 curl https://get.wasmer.io -sSfL | sh
 

--- a/_posts/wasmer-go-embedding-1.0.md
+++ b/_posts/wasmer-go-embedding-1.0.md
@@ -21,12 +21,16 @@ thousands of installations, it's our great pleasure to introduce the
 better performance, cross-compilation, two compilers, two engines, and
 many more advanced features!
 
-* [Improved and simplified API](#improved-and-simplified-api)
-* [Compilers and Engines](#compilers-and-engines)
-* [Cross-compilation](#cross-compilation)
-* [WASI](#wasi)
-* [Ready to use on major platforms and
-  architectures](#ready-to-use-on-major-platforms-and-architectures)
+- [Improved and simplified API](#improved-and-simplified-api)
+  - [A word about host functions](#a-word-about-host-functions)
+  - [A word about exported functions](#a-word-about-exported-functions)
+- [Compilers and Engines](#compilers-and-engines)
+  - [Cranelift has new companions: Singlepass and LLVM!](#cranelift-has-new-companions-singlepass-and-llvm)
+  - [JIT and Native engines](#jit-and-native-engines)
+- [Cross-compilation](#cross-compilation)
+- [WASI](#wasi)
+- [Ready to use on major platforms and architectures](#ready-to-use-on-major-platforms-and-architectures)
+- [Conclusion](#conclusion)
 
 ## Improved and simplified API
 
@@ -128,7 +132,6 @@ A couple of interesting things can be seen here:
    “externals”: `Function`, `Memory` etc., i.e. any type that
    implements the `IntoExtern` interface, to a given namespace (here
    `math`),
-   
 6. The `Exports` API allows to read any kinds of exports, including
    multiple memories.
 
@@ -226,8 +229,8 @@ name.
 i.e. a function that can be invoked as `addOne(42)`. It's actually an
 alias of `GetRawFunction(name).Native()` (including error handling):
 
-* A _raw function_ is represented by the type `Function`,
-* A _native function_ is represented by the type `NativeFunction`.
+- A _raw function_ is represented by the type `Function`,
+- A _native function_ is represented by the type `NativeFunction`.
 
 The `Function` type provides more information about the function
 itself, whilst `NativeFunction` serves the purpose of being easy to
@@ -262,12 +265,11 @@ various contexts.
 The Wasmer runtime provides 3 compilers to compile the WebAssembly
 modules into executable codes:
 
-* Singlepass: Super fast compilation times, slow execution times. Not
+- Singlepass: Super fast compilation times, slow execution times. Not
   prone to JIT-bombs,
-  
-* Cranelift: Fast compilation times, fast execution times,
+- Cranelift: Fast compilation times, fast execution times,
 
-* LLVM: Slow compilation times, very fast execution times (close to
+- LLVM: Slow compilation times, very fast execution times (close to
   native).
 
 Previously, `wasmer-go` was providing only one compiler:
@@ -313,9 +315,9 @@ The Wasmer runtime also provides 3 engines to compile _and_ to execute
 WebAssembly modules. Let's only keep 2 engines in this article. In a
 nutshell:
 
-* The JIT engine stores the executable code in memory,
+- The JIT engine stores the executable code in memory,
 
-* The Native engine stores the executable code in a native shared
+- The Native engine stores the executable code in a native shared
   library object (`.so`, `.dylib`, or `.dll` files depending on the
   Operating System it runs),
 
@@ -498,16 +500,16 @@ aims at being run anywhere.
 `wasmer-go` embeds the Wasmer runtime as native shared object library
 (`.so`, `.dylib` etc.) for the following platforms:
 
-* Linux on `amd64`,
-* Linux on `arm64`,
-* Darwin on `amd64`.
+- Linux on `amd64`,
+- Linux on `arm64`,
+- Darwin on `amd64`.
 
 More is coming very soon, like Windows, Linux with `musl`, and more!
 
 If you want to use a custom configuration of Wasmer, we've got you
 covered with the `custom_wasmer_runtime` build tag.
 
-```shell
+```shell-session
 $ # Configure cgo.
 $ export CGO_CFLAGS="-I/path/to/include/"
 $ export CGO_LDFLAGS="-Wl,-rpath,/path/to/lib/ -L/path/to/lib/ -lwasmer_go"

--- a/_posts/wasmer-takes-webassembly-libraries-manistream-with-wai.md
+++ b/_posts/wasmer-takes-webassembly-libraries-manistream-with-wai.md
@@ -1,8 +1,8 @@
 ---
-title: "Wasmer takes WebAssembly libraries mainstream with WAI"
-excerpt: "Import WebAssembly libraries just like any other dependency in your project"
-date: "2022-12-02T10:00:00.000Z"
-coverImage: "/images/blog/use-wai.png"
+title: 'Wasmer takes WebAssembly libraries mainstream with WAI'
+excerpt: 'Import WebAssembly libraries just like any other dependency in your project'
+date: '2022-12-02T10:00:00.000Z'
+coverImage: '/images/blog/use-wai.png'
 author: Michael Bryan
 published: true
 ---
@@ -21,7 +21,7 @@ The WAI addition to the [WebAssembly Package Manager](https://wapm.io/) streamli
 
 In fact, you can see it in action right now with [the `vscode-wasm` plugin][vscode-wasm] which uses the automatically generated [wabt WAI bindings](https://wapm.io/wasmer/wabt), used by more than 94 thousand developers worldwide!
 
-*WAPM is not tied to just the WAI format though, we are working to allow integrating **any kind of Wasm bindings** into the Package Manager (such as [Extism](https://extism.org/))... if you maintain a binding format we want to hear from you!*
+_WAPM is not tied to just the WAI format though, we are working to allow integrating **any kind of Wasm bindings** into the Package Manager (such as [Extism](https://extism.org/))... if you maintain a binding format we want to hear from you!_
 
 [component-model]: https://github.com/WebAssembly/component-model
 [interface-types]: https://github.com/WebAssembly/interface-types/blob/main/proposals/interface-types/Explainer.md
@@ -74,7 +74,7 @@ impl crate::calculator::Calculator for Calculator {
 
 ### Let’s publish it!
 
-Publishing requires installing `wapm` with [the Wasmer installer](https://docs.wasmer.io/ecosystem/wapm/getting-started) and the [`cargo wapm`](https://github.com/wasmerio/cargo-wapm)  helper installed (`cargo install cargo-wapm`). If you haven't already, make sure to run `wapm login` to log into your WAPM account (don't forget to [sign up][sign-up] if you haven't already).
+Publishing requires installing `wapm` with [the Wasmer installer](https://docs.wasmer.io/ecosystem/wapm/getting-started) and the [`cargo wapm`](https://github.com/wasmerio/cargo-wapm) helper installed (`cargo install cargo-wapm`). If you haven't already, make sure to run `wapm login` to log into your WAPM account (don't forget to [sign up][sign-up] if you haven't already).
 
 Now we're set up, we'll need to update `Cargo.toml` so this package can be published to WAPM.
 
@@ -95,7 +95,6 @@ Now we need to tell the Rust compiler to generate a `cdylib` ("C-compatible
 dynamic library"). It's also a good idea to add the `rlib` crate type so
 integration tests can import the library as a Rust dependency.
 
-
 ```toml
 # Cargo.toml
 [lib]
@@ -104,11 +103,11 @@ crate-type = ["cdylib", "rlib"]
 
 And publish!
 
-```console
+```shell-session
 $ cargo wapm
 ```
 
-*Note: WAI also works with other languages, such as C or C++. If you want to publish packages to WAPM with it, you will need to use `wapm publish` instead of `cargo wapm`.*
+_Note: WAI also works with other languages, such as C or C++. If you want to publish packages to WAPM with it, you will need to use `wapm publish` instead of `cargo wapm`._
 
 ## Consuming WAPM Packages in your codebase
 
@@ -116,7 +115,7 @@ Let's add this `wai/tutorial-01` package to a JavaScript project.
 
 First, we'll need to create a new JavaScript package and add the `wai/tutorial-01` package as a dependency.
 
-```console
+```shell-session
 $ wasmer add --yarn wai/tutorial-01
 ```
 
@@ -125,12 +124,12 @@ This runs `yarn add` under the hood. Depending on the project, you might use the
 Now, let's create a script.
 
 ```jsx
-import { bindings } from "wai/tutorial-01";
+import { bindings } from 'wai/tutorial-01';
 
 async function main() {
-	const calculator = await bindings.calculator();
-	const four = calculator.add(2, 2);
-	console.log("2 + 2 =", four);
+  const calculator = await bindings.calculator();
+  const four = calculator.add(2, 2);
+  console.log('2 + 2 =', four);
 }
 
 main();
@@ -138,7 +137,7 @@ main();
 
 Or, if you want to do it in python:
 
-```console
+```shell-session
 $ wasmer add --pip wai/tutorial-01
 ```
 


### PR DESCRIPTION
Console blocks started with `'''shell` or `'''console`. This doesn't work with `prism.js`.

Fixed them to `'''shell-session` for syntax highlighting for shell