### PR TITLE
Explicitly publish to the dev registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,4 +63,4 @@ jobs:
           mv out public
 
       - name: Publish
-        run: wasmer-deploy publish --publish-package --token=${{ secrets.WAPM_DEV_TOKEN }} --non-interactive
+        run: wasmer-deploy publish --publish-package --registry https://registry.wapm.dev/graphql --token=${{ secrets.WAPM_DEV_TOKEN }} --non-interactive


### PR DESCRIPTION
In #99, I was using an unpublished version of the `wasmer-deploy` CLI which respects the `--registry` flag when publishing packages. However, the version currently on crates.io (v0.1.1) will use the registry specified in your `$WASMER_HOME/wasmer.toml` for package publishing and the `--registry` flag for app publishing (wasmerio/deploy#388)... To avoid mix-ups in the future, let's be explicit about exactly which registry is being used.